### PR TITLE
Show/hide arrow option, atan2 deprecated in Lua 5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ It is implemented as [a Spoon for Hammerspoon](https://github.com/Hammerspoon/ha
 
 2. Install FocusHighlight.spoon using Git:
 
-    ```sh
-    git clone https://github.com/dtinth/FocusHighlight.spoon.git ~/.hammerspoon/Spoons/FocusHighlight.spoon
-    ```
+   ```sh
+   git clone https://github.com/dtinth/FocusHighlight.spoon.git ~/.hammerspoon/Spoons/FocusHighlight.spoon
+   ```
 
 3. Update Hammerspoon configuration file:
 
-    ```lua
-    hs.loadSpoon("FocusHighlight")
-    spoon.FocusHighlight:start()
-    ```
+   ```lua
+   hs.loadSpoon("FocusHighlight")
+   spoon.FocusHighlight:start()
+   ```
 
 ## Customization
 
@@ -34,4 +34,5 @@ spoon.FocusHighlight.arrowSize = 256
 spoon.FocusHighlight.arrowFadeOutDuration = 1
 spoon.FocusHighlight.highlightFadeOutDuration = 1
 spoon.FocusHighlight.highlightFillAlpha = 0.1
+spoon.FocusHighlight.arrowActive = true
 ```

--- a/init.lua
+++ b/init.lua
@@ -38,6 +38,11 @@ obj.highlightFadeOutDuration = 1
 --- Controls the alpha opacity for the highlight box
 obj.highlightFillAlpha = 0.1
 
+-- FocusHighlight.arrowActive
+-- Variable
+-- Show/Hide Arrows
+obj.arrowActive = true
+
 local previousFrame = nil
 
 function obj:start()
@@ -51,12 +56,12 @@ function obj:start()
     end
 
     -- Draw an arrow if the frame moved significantly
-    if previousFrame ~= nil then
+    if previousFrame ~= nil and self.arrowActive == true then
       local arrowSize = self.arrowSize
       local arrowFrame = hs.geometry(previousFrame.x + previousFrame.w / 2 - arrowSize / 2, previousFrame.y + previousFrame.h / 2 - arrowSize / 2, arrowSize, arrowSize)
       local arrowFrameIntersection = arrowFrame:intersect(nextFrame)
       if arrowFrameIntersection.w * arrowFrameIntersection.h == 0 then
-        local angle = math.atan2(
+        local angle = math.atan(
           (nextFrame.y + nextFrame.h / 2) - (previousFrame.y + previousFrame.h / 2),
           (nextFrame.x + nextFrame.w / 2) - (previousFrame.x + previousFrame.w / 2)
         ) * 180 / 3.1415


### PR DESCRIPTION
I've been using [Amethyst](https://github.com/ianyh/Amethyst) with this spoon and it works great, the arrows are a good option if it's the first time with a tiling window manager, but it's a bit intrusive if you use it day by day.