### PR TITLE
fix: remove deprecated function

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -41,7 +41,7 @@ obj.highlightFillAlpha = 0.1
 local previousFrame = nil
 
 function obj:start()
-  self.windowFilter:subscribe(hs.window.filter.windowFocused, function(window, appName)
+  self.windowFilter:subscribe(hs.window.filter.windowFocused, function(window, _)
     local color = self.color
     local nextFrame = window:frame()
 
@@ -56,7 +56,7 @@ function obj:start()
       local arrowFrame = hs.geometry(previousFrame.x + previousFrame.w / 2 - arrowSize / 2, previousFrame.y + previousFrame.h / 2 - arrowSize / 2, arrowSize, arrowSize)
       local arrowFrameIntersection = arrowFrame:intersect(nextFrame)
       if arrowFrameIntersection.w * arrowFrameIntersection.h == 0 then
-        local angle = math.atan2(
+        local angle = math.atan(
           (nextFrame.y + nextFrame.h / 2) - (previousFrame.y + previousFrame.h / 2),
           (nextFrame.x + nextFrame.w / 2) - (previousFrame.x + previousFrame.w / 2)
         ) * 180 / 3.1415


### PR DESCRIPTION
`math.atan2` was deprecated in Lua 5.3 ([Reference](https://www.lua.org/manual/5.3/manual.html#8.2))

> The following functions were deprecated in the mathematical library: atan2, cosh, sinh, tanh, pow, frexp, and ldexp. You can replace math.pow(x,y) with x^y; you can replace math.atan2 with math.atan, which now accepts one or two arguments; ...

```lua
local angle = math.atan((Enemy_y - Player_y), (Enemy_x - Player_x))
```